### PR TITLE
[UPDATE] 나눔방 수정 로직 및 s3 이미지 처리

### DIFF
--- a/front-end/src/views/SharingRoomDetail.vue
+++ b/front-end/src/views/SharingRoomDetail.vue
@@ -36,9 +36,20 @@
                   :counter="itemNameCounter"
                   maxlength="20"
                 ></v-text-field>
+                <!-- <p v-if="itemImagePath">{{ itemImagePath.split("_").pop() }}</p>
                 <v-file-input
                   v-model="itemImage"
                   label="상품 이미지"
+                  @change="fileUpload"
+                ></v-file-input> -->
+                <v-file-input
+                  v-model="itemImage"
+                  :label="
+                    itemImagePath
+                      ? itemImagePath.split('_').pop()
+                      : '상품 이미지'
+                  "
+                  accept="image/*"
                   @change="fileUpload"
                 ></v-file-input>
                 <div class="text-right">
@@ -68,7 +79,8 @@ export default {
       contents: "",
       cntPeople: null,
       itemName: "",
-      itemImage: "",
+      itemImage: null,
+      itemImagePath: "",
     };
   },
   computed: {
@@ -120,8 +132,11 @@ export default {
     goToPage(path) {
       this.$router.push(path);
     },
+    // fileUpload(event) {
+    //   this.itemImage = event.target.files[0];
+    // },
     fileUpload(event) {
-      this.itemImage = event.target.files[0];
+      this.itemImage = event.target.files[0] || "";
     },
     async loadRoomDetail() {
       try {
@@ -135,6 +150,7 @@ export default {
         this.contents = this.room.contents;
         this.cntPeople = this.room.cntPeople;
         this.itemName = this.room.itemName;
+        this.itemImagePath = this.room.itemImagePath; // 파일명.확장자가 label에 담김
       } catch (error) {
         console.error("Error fetching sharing rooms:", error);
         alert("해당 나눔글을 불러오는 데 실패했습니다.");
@@ -149,7 +165,10 @@ export default {
           formData.append("contents", this.contents);
           formData.append("cntPeople", this.cntPeople);
           formData.append("itemName", this.itemName);
-          formData.append("itemImage", this.itemImage);
+          // formData.append("itemImage", this.itemImage);
+          if (this.itemImage) {
+            formData.append("itemImage", this.itemImage);
+          }
 
           const response = await axios.patch(
             `${process.env.VUE_APP_API_BASE_URL}/user/room/${roomId}/update`,


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 사항 설명
1. 나눔 글 수정 시 이미지 처리
   (1) 수정 시, 재업로드라면 기존 값 삭제 후 새로운 이미지 업로드
        - 기존 값 존재, 새로운 입력 값 존재에 따라 발생 가능한 경우의 수 모두 처리
   (2) 삭제 시, 묻지도 따지지도 않고 삭제
<br />

## :: Issue 포인트 
Service의 update에서 이미지 처리하는 부분이 조금 복잡합니다.
<br />

추가 구현사항
- 방 생성 시 이미지 올리면 파일명 label에 뜨게 하기
- 줄바꿈 처리(게시글, br)
