### PR TITLE
[UPDATE] 게임 진행 시 인원 관리

### DIFF
--- a/front-end/src/views/NanumGameRoom.vue
+++ b/front-end/src/views/NanumGameRoom.vue
@@ -36,6 +36,7 @@
 <style>
 .message-box {
   border: none;
+  text-align: center;
   font-size: 1.2em;
   margin-top: 50px;
   margin-bottom: 20px;
@@ -66,6 +67,12 @@ export default {
   },
   created() {
     this.connect();
+  },
+  beforeRouteLeave(to, from, next) {
+    // 라우트를 벗어나기 전에 웹소켓 연결 해제
+    // 게임 입장 후 뒤로가기 누를 경우 disconnect
+    this.disconnect();
+    next();
   },
   methods: {
     connect() {
@@ -107,7 +114,7 @@ export default {
             this.messageToReceived = message.body;
           });
 
-          const destination2 = `/queue/sharing/${this.id}`; 
+          const destination2 = `/queue/sharing/${this.id}`;
           this.stompClient.subscribe(destination2, (message) => {
             console.log("메시지 수신", message);
             const messageIdPrefix = message.headers["message-id"].slice(0, 8);

--- a/front-end/src/views/SharingForm.vue
+++ b/front-end/src/views/SharingForm.vue
@@ -3,8 +3,10 @@
     <v-container class="v-container">
       <v-row justify="center">
         <v-col cols="12" md="6">
-          <v-card>
-            <v-card-title class="text-center">나눔 글쓰기</v-card-title>
+          <v-card class="d-flex flex-column justify-content-center">
+            <v-card-title class="custom-title d-flex" style="margin-top: 20px">
+              <div class="align-self-center mx-auto">나눔 글쓰기</div>
+            </v-card-title>
             <v-card-text>
               <v-form @submit.prevent="roomCreate">
                 <v-text-field
@@ -40,7 +42,11 @@
                   :error="itemNameErrors.length > 0"
                 ></v-text-field>
                 <v-file-input
-                  label="상품 이미지"
+                  :label="
+                    itemImagePath
+                      ? itemImagePath.split('_').pop()
+                      : '상품 이미지'
+                  "
                   v-model="itemImage"
                   accept="image/*"
                   @change="fileUpload"
@@ -126,6 +132,7 @@ export default {
     },
     fileUpload(event) {
       this.itemImage = event.target.files[0];
+      this.itemImagePath = event.target.files[0].name; // 파일명.확장자가 label에 담김
     },
     async roomCreate() {
       try {

--- a/front-end/src/views/SharingRoomDetail.vue
+++ b/front-end/src/views/SharingRoomDetail.vue
@@ -36,12 +36,6 @@
                   :counter="itemNameCounter"
                   maxlength="20"
                 ></v-text-field>
-                <!-- <p v-if="itemImagePath">{{ itemImagePath.split("_").pop() }}</p>
-                <v-file-input
-                  v-model="itemImage"
-                  label="상품 이미지"
-                  @change="fileUpload"
-                ></v-file-input> -->
                 <v-file-input
                   v-model="itemImage"
                   :label="

--- a/src/main/java/com/wellcom/global/socket/ChatController.java
+++ b/src/main/java/com/wellcom/global/socket/ChatController.java
@@ -63,9 +63,14 @@ public class ChatController {
         roomData.add(new UserGameData(sessionId, Integer.parseInt(req.getContent())));
         sessionData.put(roomId, roomData);
 
-        int limitPeople = sharingRoomService.findByIdForGame(roomId).getCntPeople();
-        // 모든 Client가 숫자를 입력하면 처리
-        if (roomData.size() == limitPeople) {
+//        int limitPeople = sharingRoomService.findByIdForGame(roomId).getCntPeople();
+//        // 모든 Client가 숫자를 입력하면 처리
+//        if (roomData.size() == limitPeople) {
+//            processRoomData(req.getRoomId(), roomData);
+//        }
+        int currentPeople = countMap.get(roomId);
+        // 현재 참여 중인 Client가 숫자를 입력하면 처리
+        if (roomData.size() == currentPeople) {
             processRoomData(req.getRoomId(), roomData);
         }
     }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정
<br />

## :: 구현 사항 설명
- 방 생성 시 이미지 올리면 파일명 뜨게 하기
- 게임 진행 시 결원이 생겨도, 나머지 인원으로 게임 진행
- "나가기"버튼 + 뒤로가기 누르면 disconnect -> 다른 사용자 입장 가능
<br />

# 추후 계획
- 엔터 처리(게시글, br)
- 이미 게임이 진행 중인 나눔 방에 대해 참가막기
- 사용자 별 게임 결과 DB 저장